### PR TITLE
add timeout to gRPC request and timeout, connect timeout exceptions

### DIFF
--- a/alphalogic_api/__init__.py
+++ b/alphalogic_api/__init__.py
@@ -8,7 +8,7 @@ from alphalogic_api import options
 
 VERSION_MAJOR = 0  # (System version)
 VERSION_MINOR = 0  # (Tests version)
-BUILD_NUMBER = 10   # (Issues version)
+BUILD_NUMBER = 11   # (Issues version)
 
 __version__ = '.'.join(map(str, (VERSION_MAJOR, VERSION_MINOR, BUILD_NUMBER)))
 

--- a/alphalogic_api/exceptions.py
+++ b/alphalogic_api/exceptions.py
@@ -26,5 +26,21 @@ class ComponentNotFound(Exception):
         super(ComponentNotFound, self).__init__(msg)
 
 
+class TimeoutError(Exception):
+    """
+    gRPC request timeout. See --timeout argument
+    """
+    def __init__(self, msg):
+        super(TimeoutError, self).__init__(msg)
+
+
+class ConnectError(Exception):
+    """
+    gRPC can't connect to Stub
+    """
+    def __init__(self, msg):
+        super(ConnectError, self).__init__(msg)
+
+
 class Exit(Exception):
     pass

--- a/alphalogic_api/multistub.py
+++ b/alphalogic_api/multistub.py
@@ -81,7 +81,7 @@ class MultiStub(object):
                     raise TimeoutError(err.message)
                 elif err.code() == grpc.StatusCode.UNAVAILABLE:
                     raise ConnectError(err.message)
-                raise RequestError(u'gRPC request failed (code={}): {}'.format(grpc.StatusCode.UNKNOWN, err.message))
+                raise RequestError(u'gRPC request failed (code={}): {}'.format(err.code(), err.message))
         else:
             raise IncorrectRPCRequest('{0} not found in {1}'.format(function_name, kwargs['fun_set']))
 

--- a/alphalogic_api/multistub.py
+++ b/alphalogic_api/multistub.py
@@ -2,7 +2,8 @@
 from __future__ import unicode_literals
 import grpc
 from alphalogic_api.logger import log
-from alphalogic_api.exceptions import IncorrectRPCRequest, RequestError, ComponentNotFound
+from alphalogic_api.exceptions import IncorrectRPCRequest, RequestError, ComponentNotFound, TimeoutError, ConnectError
+from alphalogic_api import options
 
 from alphalogic_api.protocol.rpc_pb2 import (
     ObjectRequest,
@@ -70,12 +71,16 @@ class MultiStub(object):
     def call_helper(self, function_name, *args, **kwargs):
         if function_name in kwargs['fun_set']:  # function_name - check availability
             try:
-                answer = getattr(kwargs['stub'], function_name)(kwargs['request'])
+                answer = getattr(kwargs['stub'], function_name)(kwargs['request'], timeout=options.args.timeout)
                 return answer
 
             except grpc.RpcError, err:
                 if err.code() == grpc.StatusCode.NOT_FOUND:
                     raise ComponentNotFound(err.message)
+                elif err.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
+                    raise TimeoutError(err.message)
+                elif err.code() == grpc.StatusCode.UNAVAILABLE:
+                    raise ConnectError(err.message)
                 raise RequestError(u'gRPC request failed (code={}): {}'.format(grpc.StatusCode.UNKNOWN, err.message))
         else:
             raise IncorrectRPCRequest('{0} not found in {1}'.format(function_name, kwargs['fun_set']))

--- a/alphalogic_api/options.py
+++ b/alphalogic_api/options.py
@@ -25,6 +25,7 @@ def parse_arguments():
     parser.add_argument('--log_max_files', type=int, default=10, help='Set max files for rotating log file. Default=10')
     parser.add_argument('--development_mode', action='store_true', help='Don\'t check configure if present')
     parser.add_argument('--log_directory', default=log_directory, help='Log files directory. Now: {}'.format(log_directory))
+    parser.add_argument('--timeout', type=int, default=3, help='gRPC request timeout, sec')
 
     global args
     args = parser.parse_args()


### PR DESCRIPTION
TimeoutError - стаб подключился, но адаптер не отвечает на запрос стаба. Обычно это бывает, если ошибся номером порта.
ConnectError - адаптер не запущен

### MacOS
ConnectError = TimeoutError = --timeout аргументу, сек
### Windows7x64 
ConnectError всегда 1 секунду
TimeoutError = --timeout аргументу, сек
### Windows10x64
ConnectError всегда 2 секунды
TimeoutError = --timeout аргументу, сек
